### PR TITLE
Refactored the MinKey and MaxKey methods to accept an IComparer<TObs>

### DIFF
--- a/RunningStatistics.Tests/CountMap/TestCountMap.cs
+++ b/RunningStatistics.Tests/CountMap/TestCountMap.cs
@@ -1,8 +1,161 @@
 using System;
+using System.Collections.Generic;
+using Xunit;
 
 namespace RunningStatistics.Tests.CountMap;
 
 public partial class TestCountMap()
     : AbstractRunningStatsTest<int, CountMap<int>>(
-        () => Random.Shared.Next(0, 100), 
-        () => new CountMap<int>());
+        () => Random.Shared.Next(0, 100),
+        () => new CountMap<int>())
+{
+    [Fact]
+    public void MinKey_ThrowsIfEmpty()
+    {
+        var countMap = new CountMap<int>();
+        Assert.Throws<KeyNotFoundException>(() => countMap.MinKey());
+    }
+
+    [Fact]
+    public void MaxKey_ThrowsIfEmpty()
+    {
+        var countMap = new CountMap<int>();
+        Assert.Throws<KeyNotFoundException>(() => countMap.MaxKey());
+    }
+    
+    [Fact]
+    public void MinKey_ThrowsIfObservationIsNotComparable()
+    {
+        var countMap = new CountMap<object>();
+        countMap.Fit(new object(), 1);
+        countMap.Fit(new object(), 2);
+        Assert.Throws<ArgumentException>(() => countMap.MinKey());
+    }
+
+    [Fact]
+    public void MaxKey_ThrowsIfObservationIsNotComparable()
+    {
+        var countMap = new CountMap<object>();
+        countMap.Fit(new object(), 1);
+        countMap.Fit(new object(), 2);
+        Assert.Throws<ArgumentException>(() => countMap.MaxKey());
+    }
+    
+    [Fact]
+    public void MinKey_ReturnsMinimumKeyForNumerics()
+    {
+        var countMap = new CountMap<int>();
+        countMap.Fit(1, 2);
+        countMap.Fit(2, 3);
+        countMap.Fit(3, 1);
+
+        Assert.Equal(1, countMap.MinKey());
+    }
+
+    [Fact]
+    public void MaxKey_ReturnsMaximumKeyForNumerics()
+    {
+        var countMap = new CountMap<int>();
+        countMap.Fit(1, 2);
+        countMap.Fit(2, 3);
+        countMap.Fit(3, 1);
+
+        Assert.Equal(3, countMap.MaxKey());
+    }
+    
+    [Fact]
+    public void MinKey_ReturnsMinimumKeyForStrings()
+    {
+        var countMap = new CountMap<string>();
+        countMap.Fit("a", 2);
+        countMap.Fit("b", 3);
+        countMap.Fit("c", 1);
+
+        Assert.Equal("a", countMap.MinKey());
+    }
+
+    [Fact]
+    public void MaxKey_ReturnsMaximumKeyForStrings()
+    {
+        var countMap = new CountMap<string>();
+        countMap.Fit("a", 2);
+        countMap.Fit("b", 3);
+        countMap.Fit("c", 1);
+
+        Assert.Equal("c", countMap.MaxKey());
+    }
+    
+    [Fact]
+    public void MinKey_UsesCustomComparer()
+    {
+        var comparer = Comparer<int>.Create((x, y) => Comparer<int>.Default.Compare(-x, -y));
+        var countMap = new CountMap<int>();
+        countMap.Fit(1, 2);
+        countMap.Fit(2, 3);
+        countMap.Fit(3, 1);
+        Assert.Equal(3, countMap.MinKey(comparer));
+    }
+
+    [Fact]
+    public void MaxKey_UsesCustomComparer()
+    {
+        var comparer = Comparer<int>.Create((x, y) => Comparer<int>.Default.Compare(-x, -y));
+        var countMap = new CountMap<int>();
+        countMap.Fit(1, 2);
+        countMap.Fit(2, 3);
+        countMap.Fit(3, 1);
+        Assert.Equal(1, countMap.MaxKey(comparer));
+    }
+    
+    [Fact]
+    public void CountMap_WithCustomComparer_MinKey_ReturnsCorrectValue()
+    {
+        var comparer = Comparer<int>.Create((x, y) => Comparer<int>.Default.Compare(-x, -y));
+        var countMap = new CountMap<int>(comparer);
+        
+        countMap.Fit(1, 2);
+        countMap.Fit(2, 3);
+        countMap.Fit(3, 1);
+        
+        Assert.Equal(3, countMap.MinKey());
+    }
+    
+    [Fact]
+    public void CountMap_WithCustomComparer_MaxKey_ReturnsCorrectValue()
+    {
+        var comparer = Comparer<int>.Create((x, y) => Comparer<int>.Default.Compare(-x, -y));
+        var countMap = new CountMap<int>(comparer);
+        
+        countMap.Fit(1, 2);
+        countMap.Fit(2, 3);
+        countMap.Fit(3, 1);
+        
+        Assert.Equal(1, countMap.MaxKey());
+    }
+    
+    [Fact]
+    public void CountMap_MinKey_NullComparer_UsesDefaultComparer()
+    {
+        var comparer = Comparer<int>.Create((x, y) => Comparer<int>.Default.Compare(-x, -y));
+        var countMap = new CountMap<int>(comparer);
+        
+        countMap.Fit(1, 2);
+        countMap.Fit(2, 3);
+        countMap.Fit(3, 1);
+        
+        Assert.Equal(1, countMap.MinKey(null));
+    }
+
+    [Fact]
+    public void CountMap_MaxKey_NullComparer_UsesDefaultComparer()
+    {
+        var comparer = Comparer<int>.Create((x, y) => Comparer<int>.Default.Compare(-x, -y));
+        var countMap = new CountMap<int>(comparer);
+        
+        countMap.Fit(1, 2);
+        countMap.Fit(2, 3);
+        countMap.Fit(3, 1);
+        
+        Assert.Equal(3, countMap.MaxKey(null));
+    }
+}

--- a/RunningStatistics.Tests/CountMap/TestCountMap_Extensions.cs
+++ b/RunningStatistics.Tests/CountMap/TestCountMap_Extensions.cs
@@ -5,50 +5,6 @@ namespace RunningStatistics.Tests.CountMap;
 public partial class TestCountMap
 {
     [Fact]
-    public void MinKey_ReturnsMinimumKeyForNumerics()
-    {
-        var countMap = new CountMap<int>();
-        countMap.Fit(1, 2);
-        countMap.Fit(2, 3);
-        countMap.Fit(3, 1);
-
-        Assert.Equal(1, countMap.MinKey());
-    }
-
-    [Fact]
-    public void MaxKey_ReturnsMaximumKeyForNumerics()
-    {
-        var countMap = new CountMap<int>();
-        countMap.Fit(1, 2);
-        countMap.Fit(2, 3);
-        countMap.Fit(3, 1);
-
-        Assert.Equal(3, countMap.MaxKey());
-    }
-    
-    [Fact]
-    public void MinKey_ReturnsMinimumKeyForStrings()
-    {
-        var countMap = new CountMap<string>();
-        countMap.Fit("a", 2);
-        countMap.Fit("b", 3);
-        countMap.Fit("c", 1);
-
-        Assert.Equal("a", countMap.MinKey());
-    }
-
-    [Fact]
-    public void MaxKey_ReturnsMaximumKeyForStrings()
-    {
-        var countMap = new CountMap<string>();
-        countMap.Fit("a", 2);
-        countMap.Fit("b", 3);
-        countMap.Fit("c", 1);
-
-        Assert.Equal("c", countMap.MaxKey());
-    }
-
-    [Fact]
     public void Sum_ReturnsCorrectSum()
     {
         var countMap = new CountMap<int>();

--- a/RunningStatistics/Extensions/CountMapExtensions.cs
+++ b/RunningStatistics/Extensions/CountMapExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 // ReSharper disable MemberCanBePrivate.Global
 
@@ -10,24 +11,6 @@ namespace RunningStatistics;
 
 public static class CountMapExtensions
 {
-    /// <summary>
-    /// Find the minimum key in a CountMap.
-    /// </summary>
-    public static T MinKey<T>(this CountMap<T> countMap) where T : notnull
-    {
-        var minKey = countMap.Keys.Min();
-        return minKey ?? throw new NullReferenceException();
-    }
-    
-    /// <summary>
-    /// Find the maximum key in a CountMap.
-    /// </summary>
-    public static T MaxKey<T>(this CountMap<T> countMap) where T : notnull
-    {
-        var maxKey = countMap.Keys.Max();
-        return maxKey ?? throw new NullReferenceException();
-    }
-    
     /// <summary>
     /// Find the sum of all observations in a CountMap of integers.
     /// </summary>


### PR DESCRIPTION
Moved the MinKey and MaxKey methods from extensions to within the class to allow direct access to the internal keys enumerator. Added overloads to allow users to pass in an IComparer<TObs> to the Min/Max Key methods.